### PR TITLE
Resize application to be more mobile friendly

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,26 +11,26 @@ function App() {
       <Header />
       <Container>
       <Row>
-          <Col></Col>
-          <Col xs="auto">
-              <div class="p-3 d-flex justify-content-center">
-                <Provider store={store}>
-                  <Router>
-                    <Switch>
-                      {routes.map((route, key) => (
-                              <Route
-                                  exact
-                                  path={route.path}
-                                  key={key}
-                                  component={route.component}
-                              />
-                            ))}
-                    </Switch>
-                  </Router>
-                </Provider>
-              </div>
-          </Col>
-          <Col></Col>
+        <Col />
+        <Col xs="auto">
+          <div class="p-3 d-flex justify-content-center">
+            <Provider store={store}>
+              <Router>
+                <Switch>
+                  {routes.map((route, key) => (
+                      <Route
+                          exact
+                          path={route.path}
+                          key={key}
+                          component={route.component}
+                      />
+                  ))}
+                </Switch>
+              </Router>
+            </Provider>
+          </div>
+        </Col>
+        <Col />
       </Row>
       </Container>
     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -9,24 +9,30 @@ function App() {
   return (
     <div>
       <Header />
-      <Container><Row><Col></Col><Col xs="auto">
-      <div class="p-3 d-flex justify-content-center">
-        <Provider store={store}>
-          <Router>
-            <Switch>
-              {routes.map((route, key) => (
-                      <Route
-                          exact
-                          path={route.path}
-                          key={key}
-                          component={route.component}
-                      />
-                    ))}
-            </Switch>
-          </Router>
-        </Provider>
-      </div>
-      </Col><Col></Col></Row></Container>
+      <Container>
+      <Row>
+          <Col></Col>
+          <Col xs="auto">
+              <div class="p-3 d-flex justify-content-center">
+                <Provider store={store}>
+                  <Router>
+                    <Switch>
+                      {routes.map((route, key) => (
+                              <Route
+                                  exact
+                                  path={route.path}
+                                  key={key}
+                                  component={route.component}
+                              />
+                            ))}
+                    </Switch>
+                  </Router>
+                </Provider>
+              </div>
+          </Col>
+          <Col></Col>
+      </Row>
+      </Container>
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -3,11 +3,13 @@ import { Provider } from "react-redux";
 import store from "./redux/store";
 import { Header } from './components/Common';
 import { routes } from "./routes"
+import { Container, Row, Col } from 'reactstrap'
 
 function App() {
   return (
     <div>
       <Header />
+      <Container><Row><Col></Col><Col xs="auto">
       <div class="p-3 d-flex justify-content-center">
         <Provider store={store}>
           <Router>
@@ -24,6 +26,7 @@ function App() {
           </Router>
         </Provider>
       </div>
+      </Col><Col></Col></Row></Container>
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -10,28 +10,28 @@ function App() {
     <div>
       <Header />
       <Container>
-      <Row>
-        <Col />
-        <Col xs="auto">
-          <div class="p-3 d-flex justify-content-center">
-            <Provider store={store}>
-              <Router>
-                <Switch>
-                  {routes.map((route, key) => (
+        <Row>
+          <Col />
+          <Col xs="auto">
+            <div class="p-3 d-flex justify-content-center">
+              <Provider store={store}>
+                <Router>
+                  <Switch>
+                    {routes.map((route, key) => (
                       <Route
                           exact
                           path={route.path}
-                          key={key}
+                          key={key}``
                           component={route.component}
                       />
-                  ))}
-                </Switch>
-              </Router>
-            </Provider>
-          </div>
-        </Col>
-        <Col />
-      </Row>
+                    ))}
+                  </Switch>
+                </Router>
+              </Provider>
+            </div>
+          </Col>
+          <Col />
+        </Row>
       </Container>
     </div>
   );

--- a/src/components/Reviews/ReviewCard/index.jsx
+++ b/src/components/Reviews/ReviewCard/index.jsx
@@ -14,7 +14,8 @@ const ReviewCard = ({ title, authorId, score, body }) => {
             color="warning"
             className="mb-2"
             style={{
-                width: '36rem'
+                maxWidth: "36rem",
+                width: "90vw"
             }}
         >
             <CardBody>


### PR DESCRIPTION
Uses containers from reactstrap to place the application in the center of the screen. These containers are resizable with window size and help the application resize its elements as the window shrinks.

Additionally, cards had a manual width set before which doesn't play well with the container elements. These have been fixed to also scale down by setting the max width to the previous width and letting it scale down in accordance to screen size.