### PR TITLE
Adding the spinner to the homepage and restaurants page and making a few style fixes

### DIFF
--- a/src/components/Common/FrySpinner/index.jsx
+++ b/src/components/Common/FrySpinner/index.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { Spinner } from 'reactstrap'
+import "./spinner.css";
 
 const FrySpinner = () => {
     return (
-        <Spinner color="warning">
+        <Spinner className="spinner" color="warning">
             <p className="visually-hidden">Loading...</p>
         </Spinner>
     )

--- a/src/components/Common/FrySpinner/spinner.css
+++ b/src/components/Common/FrySpinner/spinner.css
@@ -1,0 +1,7 @@
+.spinner {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-left: auto;
+    margin-right: auto;
+}

--- a/src/components/Common/Header/style.module.css
+++ b/src/components/Common/Header/style.module.css
@@ -15,7 +15,7 @@
 }
 
 .Header a:hover {
-    color: #8B0000;
+    color: #dc3545;
 }
 
 .Header h1 {

--- a/src/components/Homepage/MessageCard/index.jsx
+++ b/src/components/Homepage/MessageCard/index.jsx
@@ -1,0 +1,23 @@
+import { Card, CardBody } from 'reactstrap';
+import { PropTypes } from 'prop-types';
+import { FrySpinner } from '../../Common';
+import Typewriter from "../Typewriter";
+
+const propTypes = {
+    message: PropTypes.string.isRequired,
+};
+
+const MessageCard = ({ message }) => {
+    return (
+        message && message.length > 0 ?
+            <Card color="warning" className="text-box">
+                <CardBody>
+                    <Typewriter text={message} delay={35} />
+                </CardBody>
+            </Card> : <FrySpinner className="spinner" />
+    )
+}
+
+MessageCard.propTypes = propTypes;
+
+export default MessageCard;

--- a/src/components/Homepage/Typewriter/index.jsx
+++ b/src/components/Homepage/Typewriter/index.jsx
@@ -1,0 +1,21 @@
+import React, { useState, useEffect } from 'react';
+
+const Typewriter = ({ text, delay }) => {
+  const [currentText, setCurrentText] = useState('');
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  useEffect(() => {
+    if (currentIndex < text.length) {
+      const timeout = setTimeout(() => {
+        setCurrentText(prevText => prevText + text[currentIndex]);
+        setCurrentIndex(prevIndex => prevIndex + 1);
+      }, delay);
+
+      return () => clearTimeout(timeout);
+    }
+  }, [currentIndex, delay, text]);
+
+  return <span>{currentText}</span>;
+};
+
+export default Typewriter;

--- a/src/components/Homepage/index.jsx
+++ b/src/components/Homepage/index.jsx
@@ -25,18 +25,7 @@ export class Homepage extends Component {
             <Link to="/restaurants" className="enter">
                 <h2>Enter FryRank</h2>
             </Link>
-<<<<<<< HEAD
-            <Card
-                color="warning"
-                className="text-box"
-            >
-                <CardBody>
-                    <Typewriter text={message} delay={35} />
-                </CardBody>
-            </Card>
-=======
             <MessageCard message={message} />
->>>>>>> spinnerUpdate
         </div>
     );
   }

--- a/src/components/Homepage/index.jsx
+++ b/src/components/Homepage/index.jsx
@@ -1,10 +1,9 @@
 import { Component } from 'react';
-import { Card, CardBody } from 'reactstrap';
 import { Link } from 'react-router-dom';
 import logo from '../../FrenchFryFoodCritic.png';
 import { BACKEND_SERVICE_PATH } from '../../constants';
-import styles from './styles.css';
-import Typewriter from "./Typewriter";
+import './styles.css';
+import MessageCard from "./MessageCard";
 
 export class Homepage extends Component {
 
@@ -26,6 +25,7 @@ export class Homepage extends Component {
             <Link to="/restaurants" className="enter">
                 <h2>Enter FryRank</h2>
             </Link>
+<<<<<<< HEAD
             <Card
                 color="warning"
                 className="text-box"
@@ -34,6 +34,9 @@ export class Homepage extends Component {
                     <Typewriter text={message} delay={35} />
                 </CardBody>
             </Card>
+=======
+            <MessageCard message={message} />
+>>>>>>> spinnerUpdate
         </div>
     );
   }

--- a/src/components/Homepage/styles.css
+++ b/src/components/Homepage/styles.css
@@ -7,11 +7,10 @@
 }
 
 .text-box {
-  display: flex;
+  width: 36rem;
+  max-width: 80vw;
   margin-left: auto;
   margin-right: auto;
-  min-width: 80vw;
-  max-width: 80vw;
 }
 
 .enter {

--- a/src/components/Restaurants/index.jsx
+++ b/src/components/Restaurants/index.jsx
@@ -1,6 +1,6 @@
 import { PropTypes } from 'prop-types';
 import { Fragment } from 'react';
-import { Breadcrumb, ErrorBanner } from '../Common';
+import { Breadcrumb, ErrorBanner, FrySpinner } from '../Common';
 import SearchInput from './SearchInput';
 import { PATH_REVIEWS, PATH_VARIABLE_RESTAURANT_ID } from '../../constants.js'
 
@@ -15,16 +15,20 @@ const propTypes = {
 const Restaurants = ({ restaurants, error, getRestaurants, currentSearchQuery, updateSearchQuery }) => {
 
     const restaurantsDisplay = (restaurants) => {
-        return restaurants
-            ? restaurants.map((restaurant, i) => {
+        if (restaurants && restaurants.length > 0) {
+            return restaurants.map((restaurant, i) => {
                 let restaurantLink = `${PATH_REVIEWS}`.replace(PATH_VARIABLE_RESTAURANT_ID, restaurant.id)
                 return (
                     <Fragment key = {i}>
                         <p><b><a href={restaurantLink}>{restaurant.displayName.text}</a></b></p>
                         <p>{restaurant.formattedAddress}</p>
                     </Fragment>
-                )})
-            : 'No restaurants found for this search.';
+                )});
+        } else if (restaurants && restaurants.length === 0) {
+            return 'No restaurants found for this search.';
+        } else {
+            return <FrySpinner />;
+        }
     }
 
     return (

--- a/src/redux/reducers/restaurants/index.js
+++ b/src/redux/reducers/restaurants/index.js
@@ -9,7 +9,7 @@ export const types = {
 }
 
 export const initialState = {
-  restaurants: [],
+  restaurants: null,
   currentRestaurant: null,
   error: '',
   requestingRestaurantDetails: false,


### PR DESCRIPTION
- Centering the spinner on the page
- Making "FryRank" word Reactstrap Red on hover (instead of a non-theme color)
- Making the Homepage message its own component to reduce complexity
- Putting the Typewriter inside of its own directory to maintain package conventions of each component in its own directory
- Making the welcome message card smaller so it doesn't stretch out ridiculously far on large screens
- Adding the spinner to the restaurants page if there is a lag in getting data from Google