### PR TITLE
Use Link from React Router DOM instead of HTML anchor tag; add methods to reset the state as needed; reuse the location every time the Restaurants page is reached

### DIFF
--- a/src/components/Common/Breadcrumb/index.jsx
+++ b/src/components/Common/Breadcrumb/index.jsx
@@ -1,5 +1,5 @@
 import { React } from 'react'
-import { useLocation } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import { Breadcrumb as ReactstrapBreadcrumb, BreadcrumbItem as ReactstrapBreadcrumbItem } from 'reactstrap'
 import { pathToPageName } from '../../../routes'
 import { PropTypes } from 'prop-types';
@@ -30,7 +30,7 @@ const Breadcrumb = ({aliases}) => {
             else {
                 return (
                     <ReactstrapBreadcrumbItem>
-                        <a href={currentLink}>{pathToPageName[currentLink] ? pathToPageName[currentLink] : crumbDisplayName}</a>
+                        <Link to={currentLink}>{pathToPageName[currentLink] ? pathToPageName[currentLink] : crumbDisplayName}</Link>
                     </ReactstrapBreadcrumbItem>
                 )
             }

--- a/src/components/Restaurants/index.jsx
+++ b/src/components/Restaurants/index.jsx
@@ -1,5 +1,6 @@
 import { PropTypes } from 'prop-types';
 import { Fragment } from 'react';
+import { Link } from 'react-router-dom';
 import { Breadcrumb, ErrorBanner, FrySpinner } from '../Common';
 import SearchInput from './SearchInput';
 import { PATH_REVIEWS, PATH_VARIABLE_RESTAURANT_ID } from '../../constants.js'
@@ -21,7 +22,7 @@ const Restaurants = ({ restaurants, error, getRestaurants, currentSearchQuery, u
                 let restaurantLink = `${PATH_REVIEWS}`.replace(PATH_VARIABLE_RESTAURANT_ID, restaurant.id)
                 return (
                     <Fragment key = {i}>
-                        <p><b><a href={restaurantLink}>{restaurant.displayName.text}</a></b></p>
+                        <p><b><Link to={restaurantLink}>{restaurant.displayName.text}</Link></b></p>
                         <p>{restaurant.formattedAddress}</p>
                     </Fragment>
                 )});

--- a/src/containers/Restaurants/index.js
+++ b/src/containers/Restaurants/index.js
@@ -23,9 +23,11 @@ export default compose(
     connect(mapStateToProps, mapDispatchToProps),
     lifecycle({
         componentDidMount() {
-            const { getRestaurants, setLocation } = this.props;
+            const { getRestaurants, location, setLocation } = this.props;
 
-            if (navigator.geolocation) {
+            if (location) {
+                getRestaurants(FRENCH_FRIES_TEXT_QUERY, location);
+            } else if (navigator.geolocation) {
                 navigator.permissions
                     .query({ name: "geolocation" })
                     .then(function (result) {

--- a/src/containers/Reviews/index.jsx
+++ b/src/containers/Reviews/index.jsx
@@ -17,14 +17,18 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = {
     getRestaurantById: restaurantsActions.startGetRestaurantByIdRequest,
-    getReviews: reviewsActions.startGetAllReviewsForRestaurantRequest
+    getReviews: reviewsActions.startGetAllReviewsForRestaurantRequest,
+    resetCurrentRestaurant: restaurantsActions.resetCurrentRestaurant,
+    resetReviews: reviewsActions.resetReviews
 };
 
 export default compose(
     connect(mapStateToProps, mapDispatchToProps),
     lifecycle({
         componentDidMount() {
-            const { match: { params: { restaurantId } }, getRestaurantById, getReviews } = this.props;
+            const { match: { params: { restaurantId } }, getRestaurantById, getReviews, resetCurrentRestaurant, resetReviews } = this.props;
+            resetCurrentRestaurant();
+            resetReviews();
             getRestaurantById(restaurantId);
             getReviews(restaurantId);
         },

--- a/src/redux/reducers/restaurants/index.js
+++ b/src/redux/reducers/restaurants/index.js
@@ -6,7 +6,8 @@ export const types = {
     GET_RESTAURANT_BY_ID_SUCCESS: "GET_RESTAURANT_BY_ID_SUCCESS",
     GET_RESTAURANT_BY_ID_FAILURE: "GET_RESTAURANT_BY_ID_FAILURE",
     UPDATE_CURRENT_SEARCH_QUERY: "UPDATE_CURRENT_SEARCH_QUERY",
-    SET_LOCATION: "SET_LOCATION"
+    SET_LOCATION: "SET_LOCATION",
+    RESET_CURRENT_RESTAURANT: "RESET_CURRENT_RESTAURANT"
 }
 
 export const initialState = {
@@ -79,6 +80,13 @@ export default (state = initialState, action) => {
             }
         }
 
+        case types.RESET_CURRENT_RESTAURANT: {
+            return {
+                ...state,
+                currentRestaurant: initialState.currentRestaurant
+            }
+        }
+
         default:
             return state;
   }
@@ -93,4 +101,5 @@ export const restaurantsActions = {
     failedGetRestaurantByIdRequest: error => ({ type: types.GET_RESTAURANT_BY_ID_FAILURE, error }),
     updateSearchQuery: data => ({ type: types.UPDATE_CURRENT_SEARCH_QUERY, data }),
     setLocation: data => ({ type: types.SET_LOCATION, data }),
+    resetCurrentRestaurant: () => ({ type: types.RESET_CURRENT_RESTAURANT })
 }

--- a/src/redux/reducers/reviews/index.js
+++ b/src/redux/reducers/reviews/index.js
@@ -6,7 +6,8 @@ export const types = {
     CREATE_REVIEW_FOR_RESTAURANT_SUCCESS: "CREATE_REVIEW_FOR_RESTAURANT_SUCCESS",
     CREATE_REVIEW_FOR_RESTAURANT_FAILURE: "CREATE_REVIEW_FOR_RESTAURANT_FAILURE",
     UPDATE_CURRENT_REVIEW: "UPDATE_CURRENT_REVIEW",
-    RESET_CREATE_REQUEST: "RESET_CREATE_REQUEST"
+    RESET_CREATE_REQUEST: "RESET_CREATE_REQUEST",
+    RESET_REVIEWS: "RESET_REVIEWS"
 }
 
 export const initialState = {
@@ -91,6 +92,13 @@ export default (state = initialState, action) => {
             }
         }
 
+        case types.RESET_REVIEWS: {
+            return {
+                ...state,
+                reviews: initialState.reviews
+            }
+        }
+
         default:
             return state;
   }
@@ -104,5 +112,6 @@ export const reviewsActions = {
     successfulCreateReviewForRestaurantRequest: () => ({ type: types.CREATE_REVIEW_FOR_RESTAURANT_SUCCESS }),
     failedCreateReviewForRestaurantRequest: error => ({ type: types.CREATE_REVIEW_FOR_RESTAURANT_FAILURE, error }),
     updateCurrentReview: (name, value) => ({ type: types.UPDATE_CURRENT_REVIEW, name, value }),
-    resetCreateRequest: () => ({ type: types.RESET_CREATE_REQUEST })
+    resetCreateRequest: () => ({ type: types.RESET_CREATE_REQUEST }),
+    resetReviews: () => ({ type: types.RESET_REVIEWS })
 }


### PR DESCRIPTION
- Use Link from React Router DOM; this allows the state to be maintained even as the user is navigated to different pages on the application
- Add reset methods for current restaurant state variable and reviews state variable. This is so that the previously viewed restaurant and its details are not displayed when a different restaurant is navigated to (without the reset methods, you see the previous restaurant details until the new ones have been retrieved)
- Reuse the location every time the Restaurants page is navigated to; this speeds up the load time