### PR TITLE
A few search enhancements: a blank search will search for nearby french fries; the search query and results are preserved when moving back and forth between searching and viewing restaurants reviews

### DIFF
--- a/src/components/Common/GoogleLogin/index.jsx
+++ b/src/components/Common/GoogleLogin/index.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { userActions } from '../../../redux/reducers/user';
-import store from '../../../redux/store';
 
 const GoogleLogin = ({ setUserData, loggedIn, givenName }) => {
 

--- a/src/components/Restaurants/SearchInput/index.jsx
+++ b/src/components/Restaurants/SearchInput/index.jsx
@@ -2,6 +2,7 @@ import { PropTypes } from 'prop-types';
 import { Form, FormGroup, Input, Label } from 'reactstrap';
 
 import { Button } from '../../Common';
+import { FRENCH_FRIES_TEXT_QUERY } from '../../../constants';
 
 const propTypes = {
     currentSearchQuery: PropTypes.string.isRequired,
@@ -24,12 +25,16 @@ const SearchInput = ({ getRestaurants, currentSearchQuery, updateSearchQuery, lo
                     name="search"
                     placeholder="Search for a restaurant"
                     type="textarea"
+                    value={currentSearchQuery}
                 />
             </FormGroup>
             <Button
                 children='Submit'
                 color='danger'
-                onClick={(event) => {getRestaurants(currentSearchQuery, location)}}
+                onClick={(event) => {
+                    const searchQuery = currentSearchQuery == '' ? FRENCH_FRIES_TEXT_QUERY : currentSearchQuery;
+                    getRestaurants(searchQuery, location);
+                }}
             />
         </Form>
     )

--- a/src/containers/Restaurants/index.js
+++ b/src/containers/Restaurants/index.js
@@ -24,30 +24,33 @@ export default compose(
     connect(mapStateToProps, mapDispatchToProps),
     lifecycle({
         componentDidMount() {
-            const { getRestaurants, location, setLocation } = this.props;
+            const { getRestaurants, location, setLocation, restaurants } = this.props;
 
-            if (location) {
-                getRestaurants(FRENCH_FRIES_TEXT_QUERY, location);
-            } else if (navigator.geolocation) {
-                navigator.permissions
-                    .query({ name: "geolocation" })
-                    .then(function (result) {
-                        if (result.state === "granted" || result.state === "prompt") {
-                            navigator.geolocation.getCurrentPosition (
-                                (position) => {
-                                    getRestaurants(FRENCH_FRIES_TEXT_QUERY, position.coords);
-                                    setLocation(position.coords);
-                                },
-                                (error) => {
+            // Only load restaurants if they have not already been loaded yet
+            if (!restaurants) {
+                if (location) {
+                        getRestaurants(FRENCH_FRIES_TEXT_QUERY, location);
+                    } else if (navigator.geolocation) {
+                        navigator.permissions
+                            .query({ name: "geolocation" })
+                            .then(function (result) {
+                                if (result.state === "granted" || result.state === "prompt") {
+                                    navigator.geolocation.getCurrentPosition (
+                                        (position) => {
+                                            getRestaurants(FRENCH_FRIES_TEXT_QUERY, position.coords);
+                                            setLocation(position.coords);
+                                        },
+                                        (error) => {
+                                            getRestaurants(FRENCH_FRIES_TEXT_QUERY);
+                                        }
+                                    );
+                                } else {
                                     getRestaurants(FRENCH_FRIES_TEXT_QUERY);
                                 }
-                            );
-                        } else {
-                            getRestaurants(FRENCH_FRIES_TEXT_QUERY);
-                        }
-                    });
-            } else {
-              getRestaurants(FRENCH_FRIES_TEXT_QUERY);
+                            });
+                    } else {
+                        getRestaurants(FRENCH_FRIES_TEXT_QUERY);
+                    }
             }
         },
     }),

--- a/src/containers/Restaurants/index.js
+++ b/src/containers/Restaurants/index.js
@@ -29,28 +29,28 @@ export default compose(
             // Only load restaurants if they have not already been loaded yet
             if (!restaurants) {
                 if (location) {
-                        getRestaurants(FRENCH_FRIES_TEXT_QUERY, location);
-                    } else if (navigator.geolocation) {
-                        navigator.permissions
-                            .query({ name: "geolocation" })
-                            .then(function (result) {
-                                if (result.state === "granted" || result.state === "prompt") {
-                                    navigator.geolocation.getCurrentPosition (
-                                        (position) => {
-                                            getRestaurants(FRENCH_FRIES_TEXT_QUERY, position.coords);
-                                            setLocation(position.coords);
-                                        },
-                                        (error) => {
-                                            getRestaurants(FRENCH_FRIES_TEXT_QUERY);
-                                        }
-                                    );
-                                } else {
-                                    getRestaurants(FRENCH_FRIES_TEXT_QUERY);
-                                }
-                            });
-                    } else {
-                        getRestaurants(FRENCH_FRIES_TEXT_QUERY);
-                    }
+                    getRestaurants(FRENCH_FRIES_TEXT_QUERY, location);
+                } else if (navigator.geolocation) {
+                    navigator.permissions
+                        .query({ name: "geolocation" })
+                        .then(function (result) {
+                            if (result.state === "granted" || result.state === "prompt") {
+                                navigator.geolocation.getCurrentPosition (
+                                    (position) => {
+                                        getRestaurants(FRENCH_FRIES_TEXT_QUERY, position.coords);
+                                        setLocation(position.coords);
+                                    },
+                                    (error) => {
+                                        getRestaurants(FRENCH_FRIES_TEXT_QUERY);
+                                    }
+                                );
+                            } else {
+                                getRestaurants(FRENCH_FRIES_TEXT_QUERY);
+                            }
+                        });
+                } else {
+                    getRestaurants(FRENCH_FRIES_TEXT_QUERY);
+                }
             }
         },
     }),


### PR DESCRIPTION
- A blank search uses the default "french fries" search using your location
- When clicking back to restaurants after viewing restaurant details, it preserves the search results and search query instead of reloading the results and removing the query
- Removing one unused import

Closes https://github.com/NickPriv/FryRankFrontend/issues/35