### PR TITLE
Passing the user's Google account ID to the backend when reviews are written

### DIFF
--- a/src/components/CreateReview/ReviewForm/index.jsx
+++ b/src/components/CreateReview/ReviewForm/index.jsx
@@ -10,15 +10,19 @@ const propTypes = {
     createReview: PropTypes.func.isRequired,
     loggedIn: PropTypes.bool.isRequired,
     givenName: PropTypes.string.isRequired,
+    accountId: PropTypes.string.isRequired,
 };
 
-const ReviewForm = ({ createReview, currentRestaurant, currentReview, updateCurrentReview, loggedIn, givenName }) => {
+const ReviewForm = ({ createReview, currentRestaurant, currentReview, updateCurrentReview, loggedIn, givenName, accountId }) => {
 
     return (
         <Form
             onChange={(event) => {
-                if (givenName && !currentReview.authorId) {
+                if (!currentReview.authorId && givenName) {
                     updateCurrentReview('authorId', givenName);
+                }
+                if (!currentReview.accountId && accountId) {
+                    updateCurrentReview('accountId', accountId);
                 }
                 updateCurrentReview(event.target.name, event.target.value);
             }}

--- a/src/components/CreateReview/index.jsx
+++ b/src/components/CreateReview/index.jsx
@@ -11,9 +11,10 @@ const propTypes = {
     createReview: PropTypes.func.isRequired,
     loggedIn: PropTypes.bool.isRequired,
     givenName: PropTypes.string.isRequired,
+    accountId: PropTypes.string.isRequired,
 };
 
-const CreateReview = ({ error, currentRestaurant, currentReview, updateCurrentReview, createReview, loggedIn, givenName }) => {
+const CreateReview = ({ error, currentRestaurant, currentReview, updateCurrentReview, createReview, loggedIn, givenName, accountId }) => {
     if (!currentRestaurant) {
         return <FrySpinner />;
     }
@@ -30,6 +31,7 @@ const CreateReview = ({ error, currentRestaurant, currentReview, updateCurrentRe
                 updateCurrentReview = {updateCurrentReview}
                 loggedIn = {loggedIn}
                 givenName = {givenName}
+                accountId = {accountId}
             />
         </div>
     )

--- a/src/containers/CreateReview/index.jsx
+++ b/src/containers/CreateReview/index.jsx
@@ -12,6 +12,7 @@ const mapStateToProps = (state) => {
         successfulCreate: state.reviewsReducer.successfulCreate,
         loggedIn: state.userReducer.loggedIn,
         givenName: state.userReducer.userData ? state.userReducer.userData.given_name : null,
+        accountId: state.userReducer.userData ? state.userReducer.userData.sub : null,
     }
 }
 

--- a/src/redux/reducers/reviews/index.js
+++ b/src/redux/reducers/reviews/index.js
@@ -19,7 +19,8 @@ export const initialState = {
     "score": null,
     "title": null,
     "body": null,
-    "isoDateTime": null
+    "isoDateTime": null,
+    "accountId": null,
   },
   error: '',
   successfulCreate: null

--- a/src/redux/sagas/reviews/index.js
+++ b/src/redux/sagas/reviews/index.js
@@ -19,7 +19,10 @@ export function* callGetAllReviewsForRestaurant({ restaurantId }) {
 
 export function* callCreateReviewForRestaurant({ review }) {
     try {
-        review[REVIEW_PROPERTY_ISO_DATE_TIME] = new Date().toISOString();
+        review = {
+            ...review,
+            [REVIEW_PROPERTY_ISO_DATE_TIME]: new Date().toISOString()
+        };
         yield axios.post(API_PATH, review);
         yield put(reviewsActions.successfulCreateReviewForRestaurantRequest());
     } catch (err) {


### PR DESCRIPTION
- Passing the accountId as part of the review when it is written
- Modified timestamp addition as state mutation was causing a warning. Instead, it creates a copy of the object and then reassigns it