### PR TITLE
Add function to sort reviews by datetime

### DIFF
--- a/src/components/Reviews/index.jsx
+++ b/src/components/Reviews/index.jsx
@@ -29,7 +29,15 @@ const Reviews = ({ reviews, reviewsError, restaurantsError, currentRestaurant, r
         } else {
             return reviews.map(review => (
                 <ReviewCard title={review.title} authorId={review.authorId} score={review.score} body={review.body} timestamp={review.isoDateTime}/>
-            ));
+            )).sort(
+                (a,b) => {
+                    // We declare the past for undefined values so that they sort to the end of the array.
+                    const past = new Date(0)
+                    let dateA = a.props.timestamp ? new Date(a.props.timestamp) : past
+                    let dateB = b.props.timestamp ? new Date(b.props.timestamp) : past
+                    return dateB.getTime() - dateA.getTime()
+                }
+            );
         }
     }
 


### PR DESCRIPTION
This commit adds a sort function to order reviews from most recently written at the top to oldest at the bottom. Old reviews without timestmaps are automatically placed at the bottom after reviews with timestamps.