### PR TITLE
Fixing UI bugs: details for restaurant not properly retrieved; username when account id is not present didn't display inline

### DIFF
--- a/src/components/Common/ReviewCard/index.jsx
+++ b/src/components/Common/ReviewCard/index.jsx
@@ -35,9 +35,8 @@ const ReviewCard = ({ review, restaurant }) => {
                 { restaurant &&
                     <div>
                         <CardSubtitle
-                            className="mb-2 me-2 text-danger"
+                            className="inline mb-2 me-2 text-danger"
                             tag="h5"
-                            style={{ display: "inline-block" }}
                         >
                             <Link to={`${PATH_RESTAURANT_REVIEWS}`.replace(PATH_VARIABLE_RESTAURANT_ID, restaurant.id)}>{restaurant.displayName.text}</Link>
                         </CardSubtitle>
@@ -54,7 +53,7 @@ const ReviewCard = ({ review, restaurant }) => {
                         ? <Link to={`${PATH_ACCOUNT_REVIEWS}`.replace(PATH_VARIABLE_ACCOUNT_ID, review.accountId)}>
                               {review.authorId ? review.authorId : review.accountId}
                           </Link>
-                        : <div>{review.authorId}</div> }
+                        : <div className="inline">{review.authorId}</div> }
                 </CardSubtitle>
                 <CardText>
                     {review.body}

--- a/src/components/Common/ReviewCardList/index.jsx
+++ b/src/components/Common/ReviewCardList/index.jsx
@@ -3,7 +3,7 @@ import { ReviewCard } from '../';
 
 const propTypes = {
     reviews: PropTypes.array.isRequired,
-    currentRestaurants: PropTypes.object.isRequired,
+    currentRestaurants: PropTypes.object,
 };
 
 const ReviewCardList = ({ reviews, currentRestaurants }) => {

--- a/src/components/CreateReview/index.jsx
+++ b/src/components/CreateReview/index.jsx
@@ -16,8 +16,8 @@ const propTypes = {
 
 const CreateReview = ({ match: { params: { restaurantId } }, error, currentRestaurants, currentReview, updateCurrentReview, createReview, loggedIn, givenName, accountId }) => {
     const currentRestaurant = currentRestaurants && currentRestaurants.size > 0
-                ? currentRestaurants.get(restaurantId)
-                : null;
+        ? currentRestaurants.get(restaurantId)
+        : null;
 
     if (!currentRestaurant) {
         return <FrySpinner />;

--- a/src/components/CreateReview/index.jsx
+++ b/src/components/CreateReview/index.jsx
@@ -14,7 +14,11 @@ const propTypes = {
     accountId: PropTypes.string.isRequired,
 };
 
-const CreateReview = ({ error, currentRestaurant, currentReview, updateCurrentReview, createReview, loggedIn, givenName, accountId }) => {
+const CreateReview = ({ match: { params: { restaurantId } }, error, currentRestaurants, currentReview, updateCurrentReview, createReview, loggedIn, givenName, accountId }) => {
+    const currentRestaurant = currentRestaurants && currentRestaurants.size > 0
+                ? currentRestaurants.get(restaurantId)
+                : null;
+
     if (!currentRestaurant) {
         return <FrySpinner />;
     }

--- a/src/components/Critic/index.jsx
+++ b/src/components/Critic/index.jsx
@@ -16,7 +16,7 @@ const Critic = ({ match: { params: { accountId } }, reviews, reviewsError, curre
         if (!reviews) {
             return <FrySpinner />;
         } else if (reviews.length == 0) {
-            return <p>Sorry, we could not identify this critic.</p>
+            return <p>Sorry, this critic has not yet published a review.</p>
         } else {
             return (
                 <ReviewCardList

--- a/src/components/Reviews/index.jsx
+++ b/src/components/Reviews/index.jsx
@@ -12,7 +12,7 @@ const propTypes = {
     loggedIn: PropTypes.bool.isRequired,
 };
 
-const Reviews = ({ reviews, reviewsError, restaurantsError, currentRestaurants, requestingRestaurantDetails, averageScore, loggedIn }) => {
+const Reviews = ({ match: { params: { restaurantId } }, reviews, reviewsError, restaurantsError, currentRestaurants, requestingRestaurantDetails, averageScore, loggedIn }) => {
     const reviewsBody = () => {
         if (!reviews) {
             return <FrySpinner />;
@@ -26,7 +26,7 @@ const Reviews = ({ reviews, reviewsError, restaurantsError, currentRestaurants, 
     }
 
     const currentRestaurant = currentRestaurants && currentRestaurants.size > 0
-            ? currentRestaurants.values().next().value
+            ? currentRestaurants.get(restaurantId)
             : null;
 
     return (

--- a/src/components/Reviews/index.jsx
+++ b/src/components/Reviews/index.jsx
@@ -26,8 +26,8 @@ const Reviews = ({ match: { params: { restaurantId } }, reviews, reviewsError, r
     }
 
     const currentRestaurant = currentRestaurants && currentRestaurants.size > 0
-            ? currentRestaurants.get(restaurantId)
-            : null;
+        ? currentRestaurants.get(restaurantId)
+        : null;
 
     return (
         <div>

--- a/src/containers/CreateReview/index.jsx
+++ b/src/containers/CreateReview/index.jsx
@@ -6,7 +6,7 @@ import { restaurantsActions } from '../../redux/reducers/restaurants'
 
 const mapStateToProps = (state) => {
     return {
-        currentRestaurant: state.restaurantsReducer.currentRestaurant,
+        currentRestaurants: state.restaurantsReducer.currentRestaurants,
         error: state.reviewsReducer.error,
         currentReview: state.reviewsReducer.currentReview,
         successfulCreate: state.reviewsReducer.successfulCreate,
@@ -17,7 +17,7 @@ const mapStateToProps = (state) => {
 }
 
 const mapDispatchToProps = {
-    getRestaurantById: restaurantsActions.startGetRestaurantByIdRequest,
+    getRestaurantsForIds: restaurantsActions.startGetRestaurantsForIdsRequest,
     createReview: reviewsActions.startCreateReviewForRestaurantRequest,
     updateCurrentReview: reviewsActions.updateCurrentReview,
     resetCreateRequest: reviewsActions.resetCreateRequest
@@ -27,9 +27,9 @@ export default compose(
     connect(mapStateToProps, mapDispatchToProps),
     lifecycle({
         componentDidMount() {
-            const { match: { params: { restaurantId } }, getRestaurantById, updateCurrentReview, resetCreateRequest } = this.props;
+            const { match: { params: { restaurantId } }, getRestaurantsForIds, updateCurrentReview, resetCreateRequest } = this.props;
             resetCreateRequest();
-            getRestaurantById(restaurantId);
+            getRestaurantsForIds([restaurantId]);
             updateCurrentReview("restaurantId", restaurantId);
         },
         componentDidUpdate() {


### PR DESCRIPTION
There was a bug where, after navigating to different restaurants for the same user, then the wrong restaurant details would display (e.g. showing "Chikin Drip" when looking at reviews for San Pedro Square).

There was also a bug that the author name was not showing inline if it wasn't associated with an account ID.

It also fixes a bug where the Create Review page was failing. This was because it did not incorporate the latest refactor to get restaurants for multiple IDs.

Also addressing comments from previous PR.