### PR TITLE
Fix bug which caused place details to be infinitely re-requested

### DIFF
--- a/src/containers/Critic/index.js
+++ b/src/containers/Critic/index.js
@@ -31,12 +31,13 @@ export default compose(
         },
         componentDidUpdate() {
             const { currentRestaurants, getRestaurantsForIds, reviews } = this.props;
-            if ((reviews && !currentRestaurants)
-                || (currentRestaurants && reviews && currentRestaurants.size != reviews.length)) {
-                const restaurantIds = reviews.map(review => review.restaurantId);
-                getRestaurantsForIds(restaurantIds);
-            }
 
+            if (reviews) {
+                const restaurantIds = new Set(reviews.map(review => review.restaurantId));
+                if (!currentRestaurants || (currentRestaurants && currentRestaurants.size != restaurantIds.size)) {
+                    getRestaurantsForIds(restaurantIds);
+                }
+            }
         }
     }),
 )(Critic);


### PR DESCRIPTION
It gets rid of the error which caused infinite re-calls to Google. It checks that the number of unique restaurant IDs in reviews is equivalent to the number of restaurants loaded, instead of checking to see if the number of reviews is equivalent to the number of restaurants. That was a problem if there were multiple reviews with the same restaurant, because then those two values would not be equivalent.