### PR TITLE
Cumulatively adding all place detail requests into the redux state in order to avoid redundant calls to Google GetPlace API

### DIFF
--- a/src/containers/CreateReview/index.jsx
+++ b/src/containers/CreateReview/index.jsx
@@ -27,9 +27,11 @@ export default compose(
     connect(mapStateToProps, mapDispatchToProps),
     lifecycle({
         componentDidMount() {
-            const { match: { params: { restaurantId } }, getRestaurantsForIds, updateCurrentReview, resetCreateRequest } = this.props;
+            const { match: { params: { restaurantId } }, getRestaurantsForIds, updateCurrentReview, resetCreateRequest, currentRestaurants } = this.props;
             resetCreateRequest();
-            getRestaurantsForIds([restaurantId]);
+            if (!currentRestaurants || !currentRestaurants.has(restaurantId)) {
+                getRestaurantsForIds([restaurantId]);
+            }
             updateCurrentReview("restaurantId", restaurantId);
         },
         componentDidUpdate() {

--- a/src/containers/Critic/index.js
+++ b/src/containers/Critic/index.js
@@ -33,10 +33,14 @@ export default compose(
             const { currentRestaurants, getRestaurantsForIds, reviews } = this.props;
             if ((reviews && !currentRestaurants)
                 || (currentRestaurants && reviews && currentRestaurants.size != reviews.length)) {
-                const restaurantIds = reviews.map(review => review.restaurantId);
-                getRestaurantsForIds(restaurantIds);
+                const restaurantIds = Array.from(new Set(reviews.map(review => review.restaurantId)));
+                const idsForRestaurantsToGetFromGoogle = currentRestaurants
+                    ? restaurantIds.filter(restaurantId => !currentRestaurants.has(restaurantId))
+                    : restaurantIds;
+                if (idsForRestaurantsToGetFromGoogle.length > 0) {
+                    getRestaurantsForIds(idsForRestaurantsToGetFromGoogle);
+                }
             }
-
         }
     }),
 )(Critic);

--- a/src/containers/Reviews/index.jsx
+++ b/src/containers/Reviews/index.jsx
@@ -27,10 +27,11 @@ export default compose(
     connect(mapStateToProps, mapDispatchToProps),
     lifecycle({
         componentDidMount() {
-            const { match: { params: { restaurantId } }, getRestaurantsForIds, getReviews, resetCurrentRestaurant, resetReviews } = this.props;
-            resetCurrentRestaurant();
+            const { match: { params: { restaurantId } }, currentRestaurants, getRestaurantsForIds, getReviews, resetReviews } = this.props;
             resetReviews();
-            getRestaurantsForIds([restaurantId]);
+            if (!currentRestaurants || !currentRestaurants.has(restaurantId)) {
+                getRestaurantsForIds([restaurantId]);
+            }
             getReviews(restaurantId);
         },
     }),

--- a/src/redux/reducers/restaurants/index.js
+++ b/src/redux/reducers/restaurants/index.js
@@ -7,7 +7,6 @@ export const types = {
     GET_RESTAURANTS_FOR_IDS_FAILURE: "GET_RESTAURANTS_FOR_IDS_FAILURE",
     UPDATE_CURRENT_SEARCH_QUERY: "UPDATE_CURRENT_SEARCH_QUERY",
     SET_LOCATION: "SET_LOCATION",
-    RESET_CURRENT_RESTAURANT: "RESET_CURRENT_RESTAURANT"
 }
 
 export const initialState = {
@@ -68,9 +67,9 @@ export default (state = initialState, action) => {
         case types.GET_RESTAURANTS_FOR_IDS_SUCCESS: {
             return {
                 ...state,
-               currentRestaurants: action.data,
-               error: '',
-               requestingRestaurantDetails: false,
+                currentRestaurants: state.currentRestaurants ? new Map([...state.currentRestaurants, ...action.data]) : action.data,
+                error: '',
+                requestingRestaurantDetails: false,
             }
         }
 
@@ -79,13 +78,6 @@ export default (state = initialState, action) => {
                 ...state,
                 error: action.error,
                 requestingRestaurantDetails: false,
-            }
-        }
-
-        case types.RESET_CURRENT_RESTAURANT: {
-            return {
-                ...state,
-                currentRestaurant: initialState.currentRestaurant
             }
         }
 
@@ -103,5 +95,4 @@ export const restaurantsActions = {
     failedGetRestaurantByIdRequest: error => ({ type: types.GET_RESTAURANTS_FOR_IDS_FAILURE, error }),
     updateSearchQuery: data => ({ type: types.UPDATE_CURRENT_SEARCH_QUERY, data }),
     setLocation: data => ({ type: types.SET_LOCATION, data }),
-    resetCurrentRestaurant: () => ({ type: types.RESET_CURRENT_RESTAURANT })
 }


### PR DESCRIPTION
This will cumulatively add all restaurant details into the redux state so that each restaurant's details are only received once from Google.

A follow-up PR will also take the places retrieved from the search and put those into the cumulative currentRestaurants state variable as well.