### PR TITLE
Save all text search place results in the state so they can be reused; read from currentRestaurants store instead of having a separate text query place list

### DIFF
--- a/src/components/Restaurants/index.jsx
+++ b/src/components/Restaurants/index.jsx
@@ -23,8 +23,8 @@ const propTypes = {
 const Restaurants = ({ restaurantIdsForQuery, error, getRestaurants, currentSearchQuery, updateSearchQuery, location, aggregateReviewsData, currentRestaurants }) => {
 
     const restaurantsDisplay = (restaurantIds) => {
-        const restaurants = restaurantIds && currentRestaurants ?
-            Array.from(currentRestaurants.values()).filter(restaurant => restaurantIds.includes(restaurant.id))
+        const restaurants = restaurantIds && currentRestaurants
+            ? Array.from(currentRestaurants.values()).filter(restaurant => restaurantIds.includes(restaurant.id))
             : null;
 
         if (restaurants && restaurants.length > 0) {

--- a/src/components/Restaurants/index.jsx
+++ b/src/components/Restaurants/index.jsx
@@ -23,7 +23,9 @@ const propTypes = {
 const Restaurants = ({ restaurantIdsForQuery, error, getRestaurants, currentSearchQuery, updateSearchQuery, location, aggregateReviewsData, currentRestaurants }) => {
 
     const restaurantsDisplay = (restaurantIds) => {
-        const restaurants = currentRestaurants ? Array.from(currentRestaurants.values()).filter(restaurant => restaurantIds.includes(restaurant.id)) : null;
+        const restaurants = restaurantIds && currentRestaurants ?
+            Array.from(currentRestaurants.values()).filter(restaurant => restaurantIds.includes(restaurant.id))
+            : null;
 
         if (restaurants && restaurants.length > 0) {
             return restaurants.map((restaurant, i) => {

--- a/src/components/Restaurants/index.jsx
+++ b/src/components/Restaurants/index.jsx
@@ -10,7 +10,8 @@ import style from './style.css';
 import { Score } from "../Common"
 
 const propTypes = {
-    restaurants: PropTypes.array.isRequired,
+    restaurantIdsForQuery: PropTypes.array.isRequired,
+    currentRestaurants: PropTypes.object.isRequired,
     error: PropTypes.string.isRequired,
     getRestaurants: PropTypes.func.isRequired,
     currentSearchQuery: PropTypes.string.isRequired,
@@ -19,8 +20,11 @@ const propTypes = {
     aggregateReviewsData: PropTypes.object.isRequired
 }
 
-const Restaurants = ({ restaurants, error, getRestaurants, currentSearchQuery, updateSearchQuery, location, aggregateReviewsData }) => {
-    const restaurantsDisplay = (restaurants) => {
+const Restaurants = ({ restaurantIdsForQuery, error, getRestaurants, currentSearchQuery, updateSearchQuery, location, aggregateReviewsData, currentRestaurants }) => {
+
+    const restaurantsDisplay = (restaurantIds) => {
+        const restaurants = currentRestaurants ? Array.from(currentRestaurants.values()).filter(restaurant => restaurantIds.includes(restaurant.id)) : null;
+
         if (restaurants && restaurants.length > 0) {
             return restaurants.map((restaurant, i) => {
                 let restaurantLink = `${PATH_RESTAURANT_REVIEWS}`.replace(PATH_VARIABLE_RESTAURANT_ID, restaurant.id)
@@ -38,6 +42,7 @@ const Restaurants = ({ restaurants, error, getRestaurants, currentSearchQuery, u
         }
     }
 
+
     return (
         <div>
             <ErrorBanner error = {error} />
@@ -48,7 +53,7 @@ const Restaurants = ({ restaurants, error, getRestaurants, currentSearchQuery, u
                 updateSearchQuery = {updateSearchQuery}
                 location = {location}
             />
-            {restaurantsDisplay(restaurants)}
+            {restaurantsDisplay(restaurantIdsForQuery)}
         </div>
     );
 }

--- a/src/containers/Restaurants/index.js
+++ b/src/containers/Restaurants/index.js
@@ -6,7 +6,8 @@ import { FRENCH_FRIES_TEXT_QUERY } from '../../constants';
 
 const mapStateToProps = (state) => {
     return {
-        restaurants: state.restaurantsReducer.restaurants,
+        restaurantIdsForQuery: state.restaurantsReducer.restaurantIdsForQuery,
+        currentRestaurants: state.restaurantsReducer.currentRestaurants,
         error: state.restaurantsReducer.error,
         currentSearchQuery: state.restaurantsReducer.searchQuery,
         location: state.restaurantsReducer.location,
@@ -15,7 +16,7 @@ const mapStateToProps = (state) => {
 }
 
 const mapDispatchToProps = {
-    getRestaurants: restaurantsActions.startGetRestaurantsRequest,
+    getRestaurants: restaurantsActions.startGetRestaurantsForQueryRequest,
     updateSearchQuery: restaurantsActions.updateSearchQuery,
     setLocation: restaurantsActions.setLocation,
 };
@@ -24,10 +25,10 @@ export default compose(
     connect(mapStateToProps, mapDispatchToProps),
     lifecycle({
         componentDidMount() {
-            const { getRestaurants, location, setLocation, restaurants } = this.props;
+            const { getRestaurants, location, setLocation, restaurantIdsForQuery } = this.props;
 
-            // Only load restaurants if they have not already been loaded yet
-            if (!restaurants) {
+            // Only load nearby restaurants if they have not already been loaded yet
+            if (!restaurantIdsForQuery) {
                 if (location) {
                     getRestaurants(FRENCH_FRIES_TEXT_QUERY, location);
                 } else if (navigator.geolocation) {

--- a/src/redux/reducers/restaurants/index.js
+++ b/src/redux/reducers/restaurants/index.js
@@ -1,7 +1,7 @@
 export const types = {
-    GET_RESTAURANTS_REQUEST: "GET_RESTAURANTS_REQUEST",
-    GET_RESTAURANTS_SUCCESS: "GET_RESTAURANTS_SUCCESS",
-    GET_RESTAURANTS_FAILURE: "GET_RESTAURANTS_FAILURE",
+    GET_RESTAURANTS_FOR_QUERY_REQUEST: "GET_RESTAURANTS_FOR_QUERY_REQUEST",
+    GET_RESTAURANTS_FOR_QUERY_SUCCESS: "GET_RESTAURANTS_FOR_QUERY_SUCCESS",
+    GET_RESTAURANTS_FOR_QUERY_FAILURE: "GET_RESTAURANTS_FOR_QUERY_FAILURE",
     GET_RESTAURANTS_FOR_IDS_REQUEST: "GET_RESTAURANTS_FOR_IDS_REQUEST",
     GET_RESTAURANTS_FOR_IDS_SUCCESS: "GET_RESTAURANTS_FOR_IDS_SUCCESS",
     GET_RESTAURANTS_FOR_IDS_FAILURE: "GET_RESTAURANTS_FOR_IDS_FAILURE",
@@ -10,8 +10,8 @@ export const types = {
 }
 
 export const initialState = {
-  restaurants: null,
   currentRestaurants: null,
+  restaurantIdsForQuery: null,
   error: '',
   requestingRestaurantDetails: false,
   searchQuery: '',
@@ -21,22 +21,27 @@ export const initialState = {
 
 export default (state = initialState, action) => {
     switch (action.type) {
-        case types.GET_RESTAURANTS_REQUEST: {
+        case types.GET_RESTAURANTS_FOR_QUERY_REQUEST: {
             return {
                 ...state
             };
         }
 
-        case types.GET_RESTAURANTS_SUCCESS: {
+        case types.GET_RESTAURANTS_FOR_QUERY_SUCCESS: {
+
+            const queriedRestaurantsMap = new Map();
+            action.data.places.forEach(place => queriedRestaurantsMap.set(place.id, place));
+
             return {
                 ...state,
-                restaurants: action.data.places,
+                currentRestaurants: state.currentRestaurants ? new Map([...state.currentRestaurants, ...queriedRestaurantsMap]) : queriedRestaurantsMap,
+                restaurantIdsForQuery: action.data.places.map(place => place.id),
                 aggregateReviewsData: action.aggregateReviewsData,
                 error: ''
             };
         }
 
-        case types.GET_RESTAURANTS_FAILURE: {
+        case types.GET_RESTAURANTS_FOR_QUERY_FAILURE: {
             return {
                 ...state,
                 error: action.error,
@@ -87,12 +92,12 @@ export default (state = initialState, action) => {
 }
 
 export const restaurantsActions = {
-    startGetRestaurantsRequest: (textQuery, location) => ({ type: types.GET_RESTAURANTS_REQUEST, textQuery, location }),
-    successfulGetRestaurantsRequest: (data, aggregateReviewsData) => ({ type: types.GET_RESTAURANTS_SUCCESS, data, aggregateReviewsData}),
-    failedGetRestaurantsRequest: error => ({ type: types.GET_RESTAURANTS_FAILURE, error }),
+    startGetRestaurantsForQueryRequest: (textQuery, location) => ({ type: types.GET_RESTAURANTS_FOR_QUERY_REQUEST, textQuery, location }),
+    successfulGetRestaurantsForQueryRequest: (data, aggregateReviewsData) => ({ type: types.GET_RESTAURANTS_FOR_QUERY_SUCCESS, data, aggregateReviewsData}),
+    failedGetRestaurantsForQueryRequest: error => ({ type: types.GET_RESTAURANTS_FOR_QUERY_FAILURE, error }),
     startGetRestaurantsForIdsRequest: restaurantIds => ({ type: types.GET_RESTAURANTS_FOR_IDS_REQUEST, restaurantIds }),
     successfulGetRestaurantsForIdsRequest: data => ({ type: types.GET_RESTAURANTS_FOR_IDS_SUCCESS, data }),
-    failedGetRestaurantByIdRequest: error => ({ type: types.GET_RESTAURANTS_FOR_IDS_FAILURE, error }),
+    failedGetRestaurantsForIdsRequest: error => ({ type: types.GET_RESTAURANTS_FOR_IDS_FAILURE, error }),
     updateSearchQuery: data => ({ type: types.UPDATE_CURRENT_SEARCH_QUERY, data }),
     setLocation: data => ({ type: types.SET_LOCATION, data }),
 }

--- a/src/redux/sagas/restaurants/index.js
+++ b/src/redux/sagas/restaurants/index.js
@@ -9,7 +9,7 @@ const HEADER_CONTENT_TYPE = 'Content-Type';
 const HEADER_API_KEY = 'X-Goog-Api-Key';
 const HEADER_FIELD_MASK = 'X-Goog-FieldMask';
 
-export function* callGetRestaurants({ textQuery, location }) {
+export function* callGetRestaurantsForQuery({ textQuery, location }) {
     const locationBias = location ?
         {
             "circle": {
@@ -36,9 +36,9 @@ export function* callGetRestaurants({ textQuery, location }) {
         );
         const aggregateReviewsData = yield axios.get(AGGREGATE_INFORMATION_API_PATH, { params: { ids: (data.places.map(place => place.id).join()), rating: true } });
 
-        yield put(restaurantsActions.successfulGetRestaurantsRequest(data, aggregateReviewsData.data.restaurantIdToRestaurantInformation));
+        yield put(restaurantsActions.successfulGetRestaurantsForQueryRequest(data, aggregateReviewsData.data.restaurantIdToRestaurantInformation));
     } catch (err) {
-        yield put(restaurantsActions.failedGetRestaurantsRequest(err.response.data.error.message));
+        yield put(restaurantsActions.failedGetRestaurantsForQueryRequest(err.response.data.error.message));
     }
 }
 
@@ -60,11 +60,11 @@ export function* callGetRestaurantsForIds({ restaurantIds }) {
 
         yield put(restaurantsActions.successfulGetRestaurantsForIdsRequest(restaurantIdToDetailsMap));
     } catch (err) {
-        yield put(restaurantsActions.failedGetRestaurantByIdRequest(err.response.data.error.message));
+        yield put(restaurantsActions.failedGetRestaurantsForIdsRequest(err.response.data.error.message));
     }
 }
 
 export default function* watchRestaurantsRequest() {
-    yield takeEvery(types.GET_RESTAURANTS_REQUEST, callGetRestaurants);
+    yield takeEvery(types.GET_RESTAURANTS_FOR_QUERY_REQUEST, callGetRestaurantsForQuery);
     yield takeEvery(types.GET_RESTAURANTS_FOR_IDS_REQUEST, callGetRestaurantsForIds);
 }


### PR DESCRIPTION
- When getting search results from Google, store the places in the `currentRestaurants` state variable, along with all other place details retrieved from Google
- Store the IDs of all the search results' restaurants so they can be retrieved from the state, instead of having two copies of the same place (one in `currentRestaurants` and the other in another variable)

Closes https://github.com/NickPriv/FryRankBackend/issues/31