### PR TITLE
Stop sending author ID when creating a review and turn greeting text black

### DIFF
--- a/src/components/Common/GoogleLogin/index.jsx
+++ b/src/components/Common/GoogleLogin/index.jsx
@@ -50,7 +50,7 @@ const GoogleLogin = ({ setUserData, loggedIn, username, accountId }) => {
         <div>
             { loggedIn && username &&
                 <div>
-                    <p className="inline me-1 text-white">Hello,</p>
+                    <p className="inline me-1 text-black">Hello,</p>
                     <Link
                         to={`${PATH_ACCOUNT_REVIEWS}`.replace(PATH_VARIABLE_ACCOUNT_ID, accountId)}
                         style={{"color":"blue", "text-decoration": "underline"}}

--- a/src/components/CreateReview/ReviewForm/index.jsx
+++ b/src/components/CreateReview/ReviewForm/index.jsx
@@ -21,9 +21,6 @@ const ReviewForm = ({ createReview, currentRestaurant, currentReview, updateCurr
         <div>
         <Form
             onChange={(event) => {
-                if (!currentReview.authorId && username) {
-                    updateCurrentReview('authorId', username);
-                }
                 if (!currentReview.accountId && accountId) {
                     updateCurrentReview('accountId', accountId);
                 }


### PR DESCRIPTION
This commit adds code to stop sending author ID when creating a review because it's no longer needed with the new usernames changes causing usernames to be stored separately from reviews. Also adds a visual fix to the welcome message and turns it black like the other text in the navbar.