### PR TITLE
Using defaultValue instead of value so that score can change when selected on a new review

### DIFF
--- a/src/components/Common/ScoreDropdown/index.jsx
+++ b/src/components/Common/ScoreDropdown/index.jsx
@@ -9,7 +9,7 @@ const ScoreDropdown = memo(({name, id, labelName, value='', onChange = () => {}}
                 type="select" 
                 name={name}
                 id={id}
-                value = {value}
+                defaultValue = {value}
                 onChange={onChange} 
                 className="form-select" 
             > 

--- a/src/components/Common/ScoreDropdown/index.jsx
+++ b/src/components/Common/ScoreDropdown/index.jsx
@@ -1,32 +1,27 @@
-import React, { memo } from 'react';
+import React from 'react';
 import { FormGroup, Label, Input } from 'reactstrap';
 
-const ScoreDropdown = memo(({name, id, labelName, value='', onChange = () => {}}) => {
+const ScoreDropdown = () => {
     return (
-        <FormGroup> 
-            <Label for="scoreInput">{labelName}</Label> 
-            <Input 
-                type="select" 
-                name={name}
-                id={id}
-                value = {value}
-                onChange={onChange} 
-                className="form-select" 
-            > 
-                <option value="">Select a {name}</option> 
-                <option value="10">10</option> 
-                <option value="9">9</option> 
-                <option value="8">8</option> 
-                <option value="7">7</option> 
-                <option value="6">6</option> 
-                <option value="5">5</option> 
-                <option value="4">4</option> 
-                <option value="3">3</option> 
-                <option value="2">2</option> 
-                <option value="1">1</option> 
-            </Input> 
+        <FormGroup>
+            <Label for="scoreInput">
+                Score
+            </Label>
+            <Input type="select" name="score" id="scoreInput" className="form-select">
+                <option></option>
+                <option>10</option>
+                <option>9</option>
+                <option>8</option>
+                <option>7</option>
+                <option>6</option>
+                <option>5</option>
+                <option>4</option>
+                <option>3</option>
+                <option>2</option>
+                <option>1</option>
+            </Input>
         </FormGroup>
     );
-});
+};
 
 export default ScoreDropdown;

--- a/src/components/Common/ScoreDropdown/index.jsx
+++ b/src/components/Common/ScoreDropdown/index.jsx
@@ -1,27 +1,32 @@
-import React from 'react';
+import React, { memo } from 'react';
 import { FormGroup, Label, Input } from 'reactstrap';
 
-const ScoreDropdown = () => {
+const ScoreDropdown = memo(({name, id, labelName, value='', onChange = () => {}}) => {
     return (
-        <FormGroup>
-            <Label for="scoreInput">
-                Score
-            </Label>
-            <Input type="select" name="score" id="scoreInput" className="form-select">
-                <option></option>
-                <option>10</option>
-                <option>9</option>
-                <option>8</option>
-                <option>7</option>
-                <option>6</option>
-                <option>5</option>
-                <option>4</option>
-                <option>3</option>
-                <option>2</option>
-                <option>1</option>
-            </Input>
+        <FormGroup> 
+            <Label for="scoreInput">{labelName}</Label> 
+            <Input 
+                type="select" 
+                name={name}
+                id={id}
+                value = {value}
+                onChange={onChange} 
+                className="form-select" 
+            > 
+                <option value="">Select a {name}</option> 
+                <option value="10">10</option> 
+                <option value="9">9</option> 
+                <option value="8">8</option> 
+                <option value="7">7</option> 
+                <option value="6">6</option> 
+                <option value="5">5</option> 
+                <option value="4">4</option> 
+                <option value="3">3</option> 
+                <option value="2">2</option> 
+                <option value="1">1</option> 
+            </Input> 
         </FormGroup>
     );
-};
+});
 
 export default ScoreDropdown;


### PR DESCRIPTION
The original fix didn't work -- it disabled the score update actually working when updating a review. So I didn't deploy the change to prod.

Turns out the simpler fix is to assign a default value. This way, the existing score will display when the edit modal opens, but the score can change when the user updates it for a new review (which wasn't happening before).

Two commits in this PR:
- Revert the previous failed change
- change `value` to `defaultValue` in the `Input` element.
