### PR TITLE
Update top reviews API endpoint to recent reviews

### DIFF
--- a/src/components/RecentReviews/index.jsx
+++ b/src/components/RecentReviews/index.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { fetchTopReviews, fetchRestaurantDetails } from '../../containers/RecentReviews';
+import { fetchRecentReviews, fetchRestaurantDetails } from '../../containers/RecentReviews';
 import { useSelector, useDispatch } from 'react-redux';
 import { FrySpinner, ReviewCardList, Banner } from '../Common';
 import { reviewsActions } from '../../redux/reducers/reviews';
@@ -16,7 +16,7 @@ const RecentReviews = () => {
         setError('');
 
         try {
-            const reviews = await fetchTopReviews();
+            const reviews = await fetchRecentReviews();
             dispatch(reviewsActions.setReviews(reviews));
             setLoading(false);
         } catch (error) {

--- a/src/containers/RecentReviews/index.js
+++ b/src/containers/RecentReviews/index.js
@@ -3,8 +3,8 @@ import { GOOGLE_API_PATH, HEADER_CONTENT_TYPE, HEADER_API_KEY, HEADER_FIELD_MASK
 
 export const reviewCount = 10;
 
-export const fetchTopReviews = async (count = reviewCount) => {
-    const response = await fetch(`${BACKEND_SERVICE_PATH}/reviews/top?count=${count}`);
+export const fetchRecentReviews = async (count = reviewCount) => {
+    const response = await fetch(`${BACKEND_SERVICE_PATH}/reviews/recent?count=${count}`);
     const newData = await response.json();
     return newData.reviews;
 };


### PR DESCRIPTION
Swap API name from top reviews to recent reviews to avoid confusion as the reviews are recent reviews and not the highest reviews as the name might imply.