### PR TITLE
Invalidating the CloudFront cache upon deployment to propagate new changes

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -37,6 +37,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Resolve deploy targets (Beta)
+        run: |
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          BUCKET_NAME="fryrank-app-spa-bucket-${ACCOUNT_ID}"
+          echo "ACCOUNT_ID=$ACCOUNT_ID" >> "$GITHUB_ENV"
+          echo "BUCKET_NAME=$BUCKET_NAME" >> "$GITHUB_ENV"
+
       - name: Fetch SSM parameters and build
         run: |
           echo "Fetching encrypted values from SSM..."
@@ -56,14 +63,25 @@ jobs:
       - name: Deploy to S3 (Beta)
         run: |
           echo "Uploading to S3..."
-
-          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
           echo "Detected AWS Account ID: $ACCOUNT_ID"
-
-          BUCKET_NAME="fryrank-app-spa-bucket-${ACCOUNT_ID}"
           echo "Using bucket: s3://$BUCKET_NAME/"
 
           aws s3 sync build/ s3://$BUCKET_NAME/ --delete || echo "S3 sync failed"
+
+      - name: Invalidate CloudFront cache (Beta)
+        run: |
+          DISTRIBUTION_ID=$(aws cloudfront list-distributions \
+            --query "DistributionList.Items[?Origins.Items[?contains(DomainName, '${BUCKET_NAME}.s3')]].Id | [0]" \
+            --output text)
+
+          if [ -z "$DISTRIBUTION_ID" ] || [ "$DISTRIBUTION_ID" = "None" ]; then
+            echo "Error: Could not find a CloudFront distribution for origin containing '${BUCKET_NAME}.s3'"
+            exit 1
+          fi
+
+          aws cloudfront create-invalidation \
+            --distribution-id "$DISTRIBUTION_ID" \
+            --paths "/*"
 
   deploy-prod:
     name: "Deploy to Production"
@@ -91,6 +109,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Resolve deploy targets (Prod)
+        run: |
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          BUCKET_NAME="fryrank-app-spa-bucket-${ACCOUNT_ID}"
+          echo "ACCOUNT_ID=$ACCOUNT_ID" >> "$GITHUB_ENV"
+          echo "BUCKET_NAME=$BUCKET_NAME" >> "$GITHUB_ENV"
+
       - name: Fetch SSM parameters and build
         run: |
           echo "Fetching encrypted values from SSM..."
@@ -110,12 +135,23 @@ jobs:
       - name: Deploy to S3 (Prod)
         run: |
           echo "Uploading to S3..."
-
-          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
           echo "Detected AWS Account ID: $ACCOUNT_ID"
-
-          BUCKET_NAME="fryrank-app-spa-bucket-${ACCOUNT_ID}"
           echo "Using bucket: s3://$BUCKET_NAME/"
 
           aws s3 sync build/ s3://$BUCKET_NAME/ --delete || echo "S3 sync failed"
+
+      - name: Invalidate CloudFront cache (Prod)
+        run: |
+          DISTRIBUTION_ID=$(aws cloudfront list-distributions \
+            --query "DistributionList.Items[?Origins.Items[?contains(DomainName, '${BUCKET_NAME}.s3')]].Id | [0]" \
+            --output text)
+
+          if [ -z "$DISTRIBUTION_ID" ] || [ "$DISTRIBUTION_ID" = "None" ]; then
+            echo "Error: Could not find a CloudFront distribution for origin containing '${BUCKET_NAME}.s3'"
+            exit 1
+          fi
+
+          aws cloudfront create-invalidation \
+            --distribution-id "$DISTRIBUTION_ID" \
+            --paths "/*"
 

--- a/deploy.bat
+++ b/deploy.bat
@@ -54,6 +54,29 @@ if %ERRORLEVEL% NEQ 0 (
     exit /b %ERRORLEVEL%
 )
 
+echo Finding CloudFront distribution for bucket origin...
+for /f "tokens=*" %%a in ('aws cloudfront list-distributions --query "DistributionList.Items[?Origins.Items[?contains(DomainName, '%BUCKET_NAME%.s3')]].Id | [0]" --output text') do set DISTRIBUTION_ID=%%a
+
+if "%DISTRIBUTION_ID%"=="" (
+    echo Error: Could not find a CloudFront distribution for origin containing '%BUCKET_NAME%.s3'
+    exit /b 1
+)
+
+if /I "%DISTRIBUTION_ID%"=="None" (
+    echo Error: Could not find a CloudFront distribution for origin containing '%BUCKET_NAME%.s3'
+    exit /b 1
+)
+
+echo Invalidating CloudFront cache for distribution: %DISTRIBUTION_ID%
+aws cloudfront create-invalidation ^
+  --distribution-id %DISTRIBUTION_ID% ^
+  --paths "/*"
+
+if %ERRORLEVEL% NEQ 0 (
+    echo Error: CloudFront invalidation failed
+    exit /b %ERRORLEVEL%
+)
+
 echo Deployment completed successfully!
 echo Your application is now available at: https://%BUCKET_NAME%.s3.amazonaws.com/index.html
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -45,5 +45,21 @@ echo "Deploying to S3 bucket: s3://$BUCKET_NAME/"
 # Sync build directory to S3
 aws s3 sync build/ "s3://$BUCKET_NAME/" --delete
 
+# Find CloudFront distribution ID for this bucket origin
+echo "Finding CloudFront distribution for bucket origin..."
+DISTRIBUTION_ID=$(aws cloudfront list-distributions \
+  --query "DistributionList.Items[?Origins.Items[?contains(DomainName, '${BUCKET_NAME}.s3')]].Id | [0]" \
+  --output text)
+
+if [ -z "$DISTRIBUTION_ID" ] || [ "$DISTRIBUTION_ID" = "None" ]; then
+  echo "Error: Could not find a CloudFront distribution for origin containing '${BUCKET_NAME}.s3'"
+  exit 1
+fi
+
+echo "Invalidating CloudFront cache for distribution: $DISTRIBUTION_ID"
+aws cloudfront create-invalidation \
+  --distribution-id "$DISTRIBUTION_ID" \
+  --paths "/*"
+
 echo "Deployment completed successfully!"
 echo "Your application is now available at: https://$BUCKET_NAME.s3.amazonaws.com/index.html"


### PR DESCRIPTION
CloudFront is being modified to have aggressive caching. Therefore, it is necessary to invalidate the cache upon deployment to force the frontend changes to apply to the website.

- Pull the CloudFront distribution ID from AWS
- Invalidate the cache after updating the S3 bucket, so that CloudFront picks up the new changes

Tested on my sandbox; deployment with cache invalidation occurred successfully